### PR TITLE
Add external CSS/JS, modernize chart colors

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,46 +8,7 @@
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Figtree:wght@400;700&display=swap" rel="stylesheet">
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
-<style>
-:root {
-  --c-bg: #ffffff;
-  --c-text: #1e2034;
-  --c-main: #414a9a;
-  --c-acc: #d74090;
-  --c-main-light: color-mix(in srgb, var(--c-main) 30%, white);
-  --c-acc-light: color-mix(in srgb, var(--c-acc) 30%, white);
-}
-* {box-sizing: border-box;}
-body {
-  margin:0;
-  font-family:'Figtree', sans-serif;
-  background:var(--c-bg);
-  color:var(--c-text);
-  scroll-behavior:smooth;
-}
-nav {
-  position:sticky;
-  top:0;
-  background:var(--c-bg);
-  display:flex;
-  justify-content:space-between;
-  padding:10px 20px;
-  z-index:1000;
-  border-bottom:1px solid #eee;
-}
-nav .brand {font-weight:700;}
-nav a {color:var(--c-text);text-decoration:none;margin-left:20px;}
-nav a:hover {text-decoration:underline;}
-section {padding:80px 20px;}
-h1,h2 {color:var(--c-text);}
-ul {list-style:disc;margin-left:20px;}
-.chart-container {opacity:0;transform:translateY(40px);transition:opacity .6s, transform .6s;max-width:600px;margin:auto;}
-.chart-container.visible {opacity:1;transform:none;}
-.flex {display:flex;flex-wrap:wrap;gap:20px;}
-.half {flex:1 1 300px;}
-canvas {max-width:100%;height:auto;}
-.small {font-size:.8rem;font-style:italic;margin-top:10px;}
-</style>
+<link rel="stylesheet" href="style.css">
 </head>
 <body>
 <nav>
@@ -103,66 +64,6 @@ canvas {max-width:100%;height:auto;}
   <p>Máte-li zájem o&nbsp;spolupráci, kontaktujte nás.</p>
 </section>
 </main>
-<script>
-document.addEventListener('DOMContentLoaded', ()=>{
-  const root = getComputedStyle(document.documentElement);
-  const cMain = root.getPropertyValue('--c-main').trim();
-  const cAcc = root.getPropertyValue('--c-acc').trim();
-  const cMainLight = root.getPropertyValue('--c-main-light').trim();
-  const cAccLight = root.getPropertyValue('--c-acc-light').trim();
-
-  function pieGradient(ctx, color, light){
-    const w = ctx.canvas.width, h = ctx.canvas.height;
-    const g = ctx.createRadialGradient(w/2,h/2,0,w/2,h/2,w/2);
-    g.addColorStop(0,'#ffffff');
-    g.addColorStop(0.7, light);
-    g.addColorStop(1, color);
-    return g;
-  }
-  function barGradient(ctx, color, light){
-    const g = ctx.createLinearGradient(0,0,ctx.canvas.width,0);
-    g.addColorStop(0,color);
-    g.addColorStop(0.7, light);
-    g.addColorStop(1,'#ffffff');
-    return g;
-  }
-  const highlight={
-    id:'highlight',
-    afterEvent(chart,args){
-      const act = chart.getActiveElements();
-      chart.data.datasets.forEach(ds=>{if(!ds._bg) ds._bg = ds.backgroundColor.slice();});
-      chart.data.datasets.forEach(ds=>ds.backgroundColor = ds._bg.slice());
-      if(act.length){
-        const {datasetIndex:index, index:i} = act[0];
-        chart.data.datasets.forEach((ds,di)=>{
-          ds.backgroundColor = ds.backgroundColor.map((c,ci)=> di===index && ci===i ? ds._bg[ci] : 'lightgray');
-        });
-      }
-      chart.update('none');
-    }
-  };
-
-  const charts=[];
-  const ctx1=document.getElementById('pie-rules').getContext('2d');
-  charts.push(new Chart(ctx1,{type:'doughnut',data:{labels:['bez pravidel','má pravidla'],datasets:[{data:[97,3],backgroundColor:[pieGradient(ctx1,cAcc,cAccLight),pieGradient(ctx1,cMain,cMainLight)],hoverOffset:5}]},options:{plugins:{legend:{display:false}}},plugins:[highlight]}));
-
-  const ctx2=document.getElementById('pie-use').getContext('2d');
-  charts.push(new Chart(ctx2,{type:'doughnut',data:{labels:['Ano','Ne'],datasets:[{data:[51,49],backgroundColor:[pieGradient(ctx2,cAcc,cAccLight),pieGradient(ctx2,cMain,cMainLight)],hoverOffset:5}]},options:{plugins:{legend:{position:'bottom'}}},plugins:[highlight]}));
-
-  const ctx3=document.getElementById('bar-areas').getContext('2d');
-  charts.push(new Chart(ctx3,{type:'bar',data:{labels:['generování textů a nápadů','komunikace s občany (web, chatboty, app)','generování obrázků','práce s daty a tabulkami','automatizace agend a opakujících se úkonů','ostatní'],datasets:[{data:[55,19,13,5,3,5],backgroundColor:Array(6).fill(barGradient(ctx3,cAcc,cAccLight)),hoverOffset:5}]},options:{indexAxis:'y',plugins:{legend:{display:false}},scales:{x:{max:60,ticks:{callback:v=>v+'%'}},y:{ticks:{font:{size:12}}}}},plugins:[highlight]}));
-
-  const ctx4=document.getElementById('pie-attitude').getContext('2d');
-  charts.push(new Chart(ctx4,{type:'doughnut',data:{labels:['pozitivní','neutrální','negativní'],datasets:[{data:[49,45,6],backgroundColor:[pieGradient(ctx4,cAcc,cAccLight),pieGradient(ctx4,cMainLight,'#ffffff'),pieGradient(ctx4,cMain,cMainLight)],hoverOffset:5,radius:'100%'},{data:[9,40,4,2],backgroundColor:[pieGradient(ctx4,cAcc,cAccLight),pieGradient(ctx4,cAccLight,'#ffffff'),pieGradient(ctx4,cMainLight,'#ffffff'),pieGradient(ctx4,cMain,cMainLight)],hoverOffset:5,radius:'70%'}]},options:{plugins:{legend:{position:'bottom'}}},plugins:[highlight]}));
-
-  const ctx5=document.getElementById('bar-barriers').getContext('2d');
-  charts.push(new Chart(ctx5,{type:'bar',data:{labels:['nízké povědomí o AI','právní/etická nejasnost','chybějící koncepce a vize','nedostatečně školený personál','nedostatek finančních prostředků','nevyhovující technická infrastruktura','odmítání AI ze strany pracovníků'],datasets:[{data:[33,15,15,15,13,5,4],backgroundColor:Array(7).fill(barGradient(ctx5,cMain,cMainLight)),hoverOffset:5}]},options:{plugins:{legend:{display:false}},scales:{y:{ticks:{font:{size:12}}},x:{max:35,ticks:{callback:v=>v+'%'}}}},plugins:[highlight]}));
-
-  window.addEventListener('resize',()=>charts.forEach(c=>c.update()));
-
-  const obs=new IntersectionObserver(en=>{en.forEach(e=>{if(e.isIntersecting){e.target.classList.add('visible');obs.unobserve(e.target);}})},{threshold:0.2});
-  document.querySelectorAll('.chart-container').forEach(el=>obs.observe(el));
-});
-</script>
+<script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,100 @@
+document.addEventListener('DOMContentLoaded', ()=>{
+  const root = getComputedStyle(document.documentElement);
+  const cMain = root.getPropertyValue('--c-main').trim();
+  const cAcc = root.getPropertyValue('--c-acc').trim();
+
+  function hexToRgba(hex, alpha){
+    const r = parseInt(hex.slice(1,3),16);
+    const g = parseInt(hex.slice(3,5),16);
+    const b = parseInt(hex.slice(5,7),16);
+    return `rgba(${r},${g},${b},${alpha})`;
+  }
+
+  function palette(n){
+    const levels=[1,1,0.8,0.8,0.6,0.6,0.4,0.4];
+    const colors=[];
+    for(let i=0;i<n;i++){
+      const base = i%2===0 ? cAcc : cMain;
+      const alpha = n<=2 ? 1 : (levels[i] ?? 0.3);
+      colors.push(n<=2 ? base : hexToRgba(base, alpha));
+    }
+    return colors;
+  }
+
+  const highlight={
+    id:'highlight',
+    afterEvent(chart){
+      const act = chart.getActiveElements();
+      chart.data.datasets.forEach(ds=>{
+        if(!ds._bg) ds._bg = ds.backgroundColor.slice();
+        ds.backgroundColor = ds._bg.slice();
+      });
+      if(act.length){
+        const {datasetIndex:index, index:i} = act[0];
+        chart.data.datasets.forEach((ds,di)=>{
+          ds.backgroundColor = ds.backgroundColor.map((c,ci)=>
+            di===index && ci===i ? ds._bg[ci] : 'lightgray');
+        });
+      }
+      chart.update('none');
+    }
+  };
+
+  const charts=[];
+  const ctx1=document.getElementById('pie-rules').getContext('2d');
+  charts.push(new Chart(ctx1,{
+    type:'doughnut',
+    data:{labels:['bez pravidel','má pravidla'],datasets:[{data:[97,3],backgroundColor:palette(2),hoverOffset:5}]},
+    options:{plugins:{legend:{display:false}}},
+    plugins:[highlight]
+  }));
+
+  const ctx2=document.getElementById('pie-use').getContext('2d');
+  charts.push(new Chart(ctx2,{
+    type:'doughnut',
+    data:{labels:['Ano','Ne'],datasets:[{data:[51,49],backgroundColor:palette(2),hoverOffset:5}]},
+    options:{plugins:{legend:{position:'bottom'}}},
+    plugins:[highlight]
+  }));
+
+  const ctx3=document.getElementById('bar-areas').getContext('2d');
+  charts.push(new Chart(ctx3,{
+    type:'bar',
+    data:{
+      labels:['generování textů a nápadů','komunikace s občany (web, chatboty, app)','generování obrázků','práce s daty a tabulkami','automatizace agend a opakujících se úkonů','ostatní'],
+      datasets:[{data:[55,19,13,5,3,5],backgroundColor:palette(6),hoverOffset:5}]
+    },
+    options:{indexAxis:'y',plugins:{legend:{display:false}},scales:{x:{max:60,ticks:{callback:v=>v+'%'}},y:{ticks:{font:{size:12}}}}},
+    plugins:[highlight]
+  }));
+
+  const ctx4=document.getElementById('pie-attitude').getContext('2d');
+  charts.push(new Chart(ctx4,{
+    type:'doughnut',
+    data:{
+      labels:['pozitivní','neutrální','negativní'],
+      datasets:[
+        {data:[49,45,6],backgroundColor:palette(3),hoverOffset:5,radius:'100%'},
+        {data:[9,40,4,2],backgroundColor:palette(4),hoverOffset:5,radius:'70%'}
+      ]
+    },
+    options:{plugins:{legend:{position:'bottom'}}},
+    plugins:[highlight]
+  }));
+
+  const ctx5=document.getElementById('bar-barriers').getContext('2d');
+  charts.push(new Chart(ctx5,{
+    type:'bar',
+    data:{
+      labels:['nízké povědomí o AI','právní/etická nejasnost','chybějící koncepce a vize','nedostatečně školený personál','nedostatek finančních prostředků','nevyhovující technická infrastruktura','odmítání AI ze strany pracovníků'],
+      datasets:[{data:[33,15,15,15,13,5,4],backgroundColor:palette(7),hoverOffset:5}]
+    },
+    options:{plugins:{legend:{display:false}},scales:{y:{ticks:{font:{size:12}}},x:{max:35,ticks:{callback:v=>v+'%'}}}},
+    plugins:[highlight]
+  }));
+
+  window.addEventListener('resize',()=>charts.forEach(c=>c.update()));
+
+  const obs=new IntersectionObserver(entries=>{entries.forEach(e=>{if(e.isIntersecting){e.target.classList.add('visible');obs.unobserve(e.target);}})},{threshold:0.2});
+  document.querySelectorAll('.chart-container').forEach(el=>obs.observe(el));
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,36 @@
+:root {
+  --c-bg: #ffffff;
+  --c-text: #1e2034;
+  --c-main: #414a9a;
+  --c-acc: #d74090;
+}
+* {box-sizing: border-box;}
+body {
+  margin:0;
+  font-family:'Figtree', sans-serif;
+  background:var(--c-bg);
+  color:var(--c-text);
+  scroll-behavior:smooth;
+}
+nav {
+  position:sticky;
+  top:0;
+  background:var(--c-bg);
+  display:flex;
+  justify-content:space-between;
+  padding:10px 20px;
+  z-index:1000;
+  border-bottom:1px solid #eee;
+}
+nav .brand {font-weight:700;}
+nav a {color:var(--c-text);text-decoration:none;margin-left:20px;}
+nav a:hover {text-decoration:underline;}
+section {padding:80px 20px;}
+h1,h2 {color:var(--c-text);}
+ul {list-style:disc;margin-left:20px;}
+.chart-container {opacity:0;transform:translateY(40px);transition:opacity .6s, transform .6s;max-width:600px;margin:auto;}
+.chart-container.visible {opacity:1;transform:none;}
+.flex {display:flex;flex-wrap:wrap;gap:20px;}
+.half {flex:1 1 300px;}
+canvas {max-width:100%;height:auto;}
+.small {font-size:.8rem;font-style:italic;margin-top:10px;}


### PR DESCRIPTION
## Summary
- move page styling to `style.css`
- move scripting to `script.js`
- generate chart colors based on number of values
- link new files from `index.html`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_687cd6018f8c8332b2c1989c61dd22c0